### PR TITLE
Replaced deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
-const gutil = require('gulp-util')
+const replaceExtension = require('replace-ext')
+const PluginError = require('plugin-error')
 const through = require('through2')
 const fs = require('fs')
 
@@ -12,9 +13,9 @@ module.exports = function (options) {
     }
     let fileReg;
     if (options.es6import) {
-        fileReg = /import\s["'](.*\.js)["']/gi
+      fileReg = /import\s["'](.*\.js)["']/gi
     } else {
-        fileReg = /@import\s["'](.*\.js)["']/gi
+      fileReg = /@import\s["'](.*\.js)["']/gi
     }
 
     if (!fs.existsSync(path)) {
@@ -22,7 +23,7 @@ module.exports = function (options) {
     }
 
     let content = fs.readFileSync(path, {
-        encoding: 'utf8'
+      encoding: 'utf8'
     })
 
     importStack[path] = path
@@ -30,9 +31,9 @@ module.exports = function (options) {
     content = content.replace(fileReg, (match, fileName) => {
       let importPath = path.replace(/[^\\^\/]*\.js$/, fileName)
       if (options.importStack) {
-          if (importPath in importStack) {
-	    return ''
-	  }
+        if (importPath in importStack) {
+          return ''
+        }
       }
 
       !options.hideConsole && console.log('import "' + fileName + '" --> "' + path + '"')
@@ -46,26 +47,26 @@ module.exports = function (options) {
   }
 
 	return through.obj(function (file, enc, cb) {
-		if (file.isNull()) {
-			cb(null, file)
-			return
-		}
+    if (file.isNull()) {
+      cb(null, file)
+      return
+    }
 
-		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-js-import', 'Streaming not supported'))
-			return
-		}
+    if (file.isStream()) {
+      cb(new PluginError('gulp-js-import', 'Streaming not supported'))
+      return
+    }
 
     let content
-    try { 
+    try {
       content = importJS(file.path)
     } catch(e) {
-      cb(new gutil.PluginError('gulp-js-import', e.message))
+      cb(new PluginError('gulp-js-import', e.message))
       return
     }
 
 		file.contents = new Buffer(content)
-		file.path = gutil.replaceExtension(file.path, '.js')
+		file.path = replaceExtension(file.path, '.js')
 		!options.hideConsole && console.log('ImportJS finished.')
 		cb(null, file)
 	})

--- a/index.js
+++ b/index.js
@@ -1,73 +1,72 @@
-'use strict'
-const replaceExtension = require('replace-ext')
-const PluginError = require('plugin-error')
-const through = require('through2')
-const fs = require('fs')
+"use strict";
+const replaceExtension = require("replace-ext");
+const PluginError = require("plugin-error");
+const through = require("through2");
+const fs = require("fs");
 
-module.exports = function (options) {
-  options = options || {};
-  let importStack = {}
-  const importJS = (path) => {
-    if (!path) {
-      return ''
-    }
-    let fileReg;
-    if (options.es6import) {
-      fileReg = /import\s["'](.*\.js)["']/gi
-    } else {
-      fileReg = /@import\s["'](.*\.js)["']/gi
-    }
+module.exports = function(options) {
+	options = options || {};
+	let importStack = {};
+	const importJS = path => {
+		if (!path) {
+			return "";
+		}
+		let fileReg;
+		if (options.es6import) {
+			fileReg = /import\s["'](.*\.js)["']/gi;
+		} else {
+			fileReg = /@import\s["'](.*\.js)["']/gi;
+		}
 
-    if (!fs.existsSync(path)) {
-      throw new Error('file ' + path + ' no exist')
-    }
+		if (!fs.existsSync(path)) {
+			throw new Error("file " + path + " no exist");
+		}
 
-    let content = fs.readFileSync(path, {
-      encoding: 'utf8'
-    })
+		let content = fs.readFileSync(path, {
+			encoding: "utf8",
+		});
 
-    importStack[path] = path
+		importStack[path] = path;
 
-    content = content.replace(fileReg, (match, fileName) => {
-      let importPath = path.replace(/[^\\^\/]*\.js$/, fileName)
-      if (options.importStack) {
-        if (importPath in importStack) {
-          return ''
-        }
-      }
+		content = content.replace(fileReg, (match, fileName) => {
+			let importPath = path.replace(/[^\\^\/]*\.js$/, fileName);
+			if (options.importStack) {
+				if (importPath in importStack) {
+					return "";
+				}
+			}
 
-      !options.hideConsole && console.log('import "' + fileName + '" --> "' + path + '"')
-      let importContent = importJS(importPath) || ''
+			!options.hideConsole && console.log('import "' + fileName + '" --> "' + path + '"');
+			let importContent = importJS(importPath) || "";
 
-      return importContent
-    })
+			return importContent;
+		});
 
+		return content;
+	};
 
-    return content
-  }
+	return through.obj(function(file, enc, cb) {
+		if (file.isNull()) {
+			cb(null, file);
+			return;
+		}
 
-	return through.obj(function (file, enc, cb) {
-    if (file.isNull()) {
-      cb(null, file)
-      return
-    }
+		if (file.isStream()) {
+			cb(new PluginError("gulp-js-import", "Streaming not supported"));
+			return;
+		}
 
-    if (file.isStream()) {
-      cb(new PluginError('gulp-js-import', 'Streaming not supported'))
-      return
-    }
+		let content;
+		try {
+			content = importJS(file.path);
+		} catch (e) {
+			cb(new PluginError("gulp-js-import", e.message));
+			return;
+		}
 
-    let content
-    try {
-      content = importJS(file.path)
-    } catch(e) {
-      cb(new PluginError('gulp-js-import', e.message))
-      return
-    }
-
-		file.contents = new Buffer(content)
-		file.path = replaceExtension(file.path, '.js')
-		!options.hideConsole && console.log('ImportJS finished.')
-		cb(null, file)
-	})
-}
+		file.contents = new Buffer(content);
+		file.path = replaceExtension(file.path, ".js");
+		!options.hideConsole && console.log("ImportJS finished.");
+		cb(null, file);
+	});
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "author": "nambo, evromalarkey",
   "dependencies": {
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
     "through2": "^2.0.1"
   },
   "repository": {


### PR DESCRIPTION
Since `gulp-util` has been deprecated, I swapped it out for the component modules as described by the guidelines  at [https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5]()

Also, some formatting got accidentally tweaked by my editor, but I tried to preserve the original code style.